### PR TITLE
Fix: Dockerfile COPY commands context

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,8 +70,7 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   #id: 1. Docker Build - to CB_LATEST # might be error prone vs the one create from computer
   id:  'step1 docker build' ##1. Docker Build - to CB_LATEST # might be error prone vs the one create from computer
-  args: ['build', '-t', "${_REGION}-docker.pkg.dev/${PROJECT_ID}/berliner-docker-repo/rails8-turbo-chat:latest", '.']
-  dir: rubyllm_chat_app/
+  args: ['build', '-t', "${_REGION}-docker.pkg.dev/${PROJECT_ID}/berliner-docker-repo/rails8-turbo-chat:latest", '-f', 'rubyllm_chat_app/Dockerfile', '.']
   env:
   - 'PROJECT_ID=$PROJECT_ID'
   - 'RAILS_MASTER_KEY=$_RAILS_MASTER_KEY'

--- a/rubyllm_chat_app/Dockerfile
+++ b/rubyllm_chat_app/Dockerfile
@@ -37,13 +37,13 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY rubyllm_chat_app/Gemfile rubyllm_chat_app/Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile
 
 # Copy application code
-COPY . .
+COPY rubyllm_chat_app/ .
 
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/

--- a/test/test_issue_13.sh
+++ b/test/test_issue_13.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if grep -q "COPY rubyllm_chat_app/Gemfile rubyllm_chat_app/Gemfile.lock ./" rubyllm_chat_app/Dockerfile; then
+  echo "Test passed: COPY Gemfile command updated correctly."
+else
+  echo "Test failed: COPY Gemfile command not updated."
+  exit 1
+fi
+
+if grep -q "COPY rubyllm_chat_app/ ." rubyllm_chat_app/Dockerfile; then
+  echo "Test passed: COPY . command updated correctly."
+else
+  echo "Test failed: COPY . command not updated."
+  exit 1
+fi


### PR DESCRIPTION
Hi Ricky ♦️ Rubacuori,

This PR addresses and resolves Issue #13. 

### What has been done:
- Updated the `COPY` commands in `rubyllm_chat_app/Dockerfile` to use the `rubyllm_chat_app/` prefix.
- Updated `cloudbuild.yaml` to run the docker build step from the repository root, removing `dir: rubyllm_chat_app/` and adding `-f rubyllm_chat_app/Dockerfile`.
- Added a failing-then-passing test `test/test_issue_13.sh` to verify the `COPY` commands are correctly pointing to `rubyllm_chat_app/`.

-- Gemini CLI v0.8.21 on behalf of Riccardo