### PR TITLE
Fix NoMethodError for Rainbow in production build (Issue #45)

### DIFF
--- a/rubyllm_chat_app/config/initializers/riccardo.rb
+++ b/rubyllm_chat_app/config/initializers/riccardo.rb
@@ -36,31 +36,33 @@ def print_env_variable(key, value=:auto_detect, limit: nil, emoji: '🌱')
   end
 end
 
-if defined?(Rainbow)
-  puts("👋 Welcome to #{Rainbow(APP_NAME).cyan} v#{Rainbow(APP_VERSION).blue}")
-else
-  puts("👋 Welcome to #{APP_NAME} v#{APP_VERSION}")
-end
-puts("")
-print_env_variable('CONFIG_AUTORENAME_TITLES', CONFIG_AUTORENAME_TITLES)
-print_env_variable('DEBUG', DEBUG)
-print_env_variable('RAILS_MASTER_KEY', RAILS_MASTER_KEY, limit: 5)
-print_env_variable('GIT_LAST_COMMENT', GIT_LAST_COMMENT)
-print_env_variable('GEMINI_API_KEY', limit: 4)
-print_env_variable('GCS_CREDENTIALS_JSON', limit: 10)
+if Rails.env.development?
+  if defined?(Rainbow)
+    puts("👋 Welcome to #{Rainbow(APP_NAME).cyan} v#{Rainbow(APP_VERSION).blue}")
+  else
+    puts("👋 Welcome to #{APP_NAME} v#{APP_VERSION}")
+  end
+  puts("")
+  print_env_variable('CONFIG_AUTORENAME_TITLES', CONFIG_AUTORENAME_TITLES)
+  print_env_variable('DEBUG', DEBUG)
+  print_env_variable('RAILS_MASTER_KEY', RAILS_MASTER_KEY, limit: 5)
+  print_env_variable('GIT_LAST_COMMENT', GIT_LAST_COMMENT)
+  print_env_variable('GEMINI_API_KEY', limit: 4)
+  print_env_variable('GCS_CREDENTIALS_JSON', limit: 10)
 
-puts("💾 [cloudbuild relevant configs]")
-print_env_variable('PROJECT_ID')
-print_env_variable('OBJC_DISABLE_INITIALIZE_FORK_SAFETY')
-print_env_variable('RAILS_ENV')
-print_env_variable('DATABASE_URL', emoji: '🔋')
-print_env_variable('APP_NAME')
-print_env_variable('GCLOUD_REGION')
-print_env_variable('GIT_LAST_COMMENT')
-print_env_variable('PORT')
-#print_env_variable('CLOUD_RUN_ENDPOINTS', CLOUD_RUN_ENDPOINTS )
-print_env_variable('CLOUD_RUN_ENDPOINTS[:dev]', CLOUD_RUN_ENDPOINTS[:dev] )
-print_env_variable('CLOUD_RUN_ENDPOINTS[:prod]', CLOUD_RUN_ENDPOINTS[:prod] )
+  puts("💾 [cloudbuild relevant configs]")
+  print_env_variable('PROJECT_ID')
+  print_env_variable('OBJC_DISABLE_INITIALIZE_FORK_SAFETY')
+  print_env_variable('RAILS_ENV')
+  print_env_variable('DATABASE_URL', emoji: '🔋')
+  print_env_variable('APP_NAME')
+  print_env_variable('GCLOUD_REGION')
+  print_env_variable('GIT_LAST_COMMENT')
+  print_env_variable('PORT')
+  #print_env_variable('CLOUD_RUN_ENDPOINTS', CLOUD_RUN_ENDPOINTS )
+  print_env_variable('CLOUD_RUN_ENDPOINTS[:dev]', CLOUD_RUN_ENDPOINTS[:dev] )
+  print_env_variable('CLOUD_RUN_ENDPOINTS[:prod]', CLOUD_RUN_ENDPOINTS[:prod] )
+end
 
 
 # Copiato da gemini-chat

--- a/rubyllm_chat_app/test/initializers/riccardo_test.rb
+++ b/rubyllm_chat_app/test/initializers/riccardo_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class RiccardoInitializerTest < ActiveSupport::TestCase
+  setup do
+    # Define Rainbow constant but not the method to simulate the production environment
+    # where the gem is not loaded, but something else defines the constant.
+    Object.const_set(:Rainbow, Module.new) unless Object.const_defined?(:Rainbow)
+  end
+
+  test "loading riccardo initializer does not raise NoMethodError for Rainbow" do
+    assert_nothing_raised do
+      load Rails.root.join('config/initializers/riccardo.rb')
+    end
+  end
+end


### PR DESCRIPTION
Hello Ricky ♦️ Rubacuori,

I have fixed the issue where the Docker build was failing on `assets:precompile` due to the `Rainbow` gem being missing in the production bundle. I wrapped the debugging statements with `if Rails.env.development?`.

I have also added a failing test in `test/initializers/riccardo_test.rb` to implement this with TDD principles, and verified it passes smoothly after the fix. 

-- Gemini CLI v0.8.21 on behalf of Riccardo