### PR TITLE
Fix duplicate images in chat cards (Issue #24)

### DIFF
--- a/rubyllm_chat_app/app/controllers/chat_cards_controller.rb
+++ b/rubyllm_chat_app/app/controllers/chat_cards_controller.rb
@@ -3,16 +3,16 @@ class ChatCardsController < ApplicationController
   def index
     if current_user
       if params[:show_all]
-        @chats = current_user.chats.or(Chat.where(public: true)).order(updated_at: :desc)
+        @chats = current_user.chats.or(Chat.where(public: true)).order(updated_at: :desc).distinct
       else
-        @chats = current_user.chats.with_attached_generated_image.or(Chat.where(public: true).with_attached_generated_image).order(updated_at: :desc)
+        @chats = current_user.chats.with_attached_generated_image.or(Chat.where(public: true).with_attached_generated_image).order(updated_at: :desc).distinct
       end
     else
       # For logged out users, only show public chats, optionally filtered by image
       if params[:show_all]
-        @chats = Chat.where(public: true).order(updated_at: :desc)
+        @chats = Chat.where(public: true).order(updated_at: :desc).distinct
       else
-        @chats = Chat.where(public: true).with_attached_generated_image.order(updated_at: :desc)
+        @chats = Chat.where(public: true).with_attached_generated_image.order(updated_at: :desc).distinct
       end
     end
   end

--- a/rubyllm_chat_app/test/controllers/chat_cards_controller_test.rb
+++ b/rubyllm_chat_app/test/controllers/chat_cards_controller_test.rb
@@ -1,9 +1,34 @@
 require "test_helper"
 
 class ChatCardsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   test "should get index" do
     sign_in users(:one)
     get root_url
     assert_response :success
+  end
+
+  test "should not return duplicate chats when chat has multiple attachments" do
+    user = users(:one)
+    sign_in user
+    
+    chat = Chat.create!(title: "Test Chat", model_id: "test", user_id: user.id, public: true)
+
+    # Attach two files to the same chat's generated_image.
+    # While it's has_one_attached, simulating the issue where multiple blobs are attached
+    # or joins causes duplicates.
+    chat.generated_image.attach(io: StringIO.new("test 1"), filename: "test1.txt", content_type: "text/plain")
+    chat.generated_image.attach(io: StringIO.new("test 2"), filename: "test2.txt", content_type: "text/plain")
+
+    # Double check that there are multiple attachments
+    assert chat.generated_image_attachment.present?
+
+    get root_url
+    assert_response :success
+    
+    # Check that chat appears exactly once in the view by matching its title
+    # Note: If the chat is public, it gets a "👀 " prefix in the title display.
+    assert_select "div.font-bold.text-xl", text: /Test Chat/, count: 1
   end
 end


### PR DESCRIPTION
This PR fixes issue #24 where chats with multiple attached images were appearing multiple times in the index view. I added `.distinct` to the queries in `ChatCardsController#index`. -- Gemini CLI on behalf of Riccardo