### PR TITLE
Fix horrible mobile chat experience

### DIFF
--- a/rubyllm_chat_app/app/views/chats/show.html.erb
+++ b/rubyllm_chat_app/app/views/chats/show.html.erb
@@ -1,8 +1,8 @@
 <%# Main container using Flexbox for two columns %>
-<div class="flex h-[calc(100vh-150px)] border border-white/10 rounded-2xl bg-white/5 backdrop-blur-xl shadow-2xl overflow-hidden chat-sidebar-container" data-controller="chat-sidebar">
+<div class="flex h-[calc(100vh-150px)] border border-white/10 rounded-2xl bg-white/5 backdrop-blur-xl shadow-2xl overflow-hidden chat-sidebar-container group" data-controller="chat-sidebar">
 
   <%# Left Pane: Chat List Sidebar %>
-  <div id="chats-list" class="chat-sidebar w-full md:w-1/4 border-r border-white/10 overflow-y-auto p-4 bg-transparent" data-chat-sidebar-target="sidebar">
+  <div id="chats-list" class="chat-sidebar hidden md:flex flex-col group-[.sidebar-open]:flex md:group-[.sidebar-open]:flex w-full md:w-1/4 border-r border-white/10 overflow-y-auto p-4 bg-transparent" data-chat-sidebar-target="sidebar">
     <h2 class="text-lg font-semibold mb-4 text-gray-200">My Chats 💬</h2>
 
     <%# Button/Form to create a new chat %>
@@ -26,7 +26,7 @@
   </div>
 
   <%# Right Pane: Chat Window %>
-  <div class="chat-content w-full md:w-3/4 flex flex-col">
+  <div class="chat-content w-full md:w-3/4 flex flex-col group-[.sidebar-open]:hidden md:group-[.sidebar-open]:flex">
     <% if @chat %>
       <%# Mobile button to show chat list %>
       <div class="md:hidden p-2 bg-transparent border-b border-white/10">

--- a/rubyllm_chat_app/test/system/chats_mobile_test.rb
+++ b/rubyllm_chat_app/test/system/chats_mobile_test.rb
@@ -1,0 +1,32 @@
+require "application_system_test_case"
+
+class ChatsMobileTest < ApplicationSystemTestCase
+  # Override screen size for this specific test
+  setup do
+    page.driver.browser.manage.window.resize_to(375, 812) # iPhone X dimensions
+    sign_in users(:one)
+    
+    @chat = Chat.create!(user_id: users(:one).id, title: "Test Chat")
+  end
+
+  test "left pane is hidden on mobile and can be toggled" do
+    visit chat_url(@chat)
+    
+    # Check that left pane is hidden (not visible)
+    assert_selector "#chats-list", visible: :hidden
+
+    # Check that the toggle button exists and is visible
+    assert_selector "#toggle-chats-list", visible: true
+    
+    # Click toggle button
+    click_button "Change Chat"
+    
+    # Left pane should now be visible
+    assert_selector "#chats-list", visible: true
+    
+    # Optional: Chat content might be hidden or just pushed down,
+    # but the main issue is that the left pane takes up too much space initially.
+    # By default, we expect the right pane to be fully visible and taking 100% width.
+    assert_selector ".chat-content", visible: :hidden
+  end
+end


### PR DESCRIPTION
This PR fixes the mobile chat experience as requested in #41. It uses Tailwind CSS group modifiers to hide the left pane by default on mobile devices, allowing the user to view the chat content clearly. The left pane can still be toggled open via the 'Change Chat' button.